### PR TITLE
Add functionality to annotate vertices during graph generation.

### DIFF
--- a/src/main/java/com/tinkerpop/furnace/generators/AbstractGenerator.java
+++ b/src/main/java/com/tinkerpop/furnace/generators/AbstractGenerator.java
@@ -1,5 +1,7 @@
 package com.tinkerpop.furnace.generators;
 
+import java.util.Map;
+
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.Vertex;
@@ -13,7 +15,24 @@ import com.tinkerpop.blueprints.Vertex;
 public abstract class AbstractGenerator {
 
     private final String label;
-    private final EdgeAnnotator annotator;
+    private final EdgeAnnotator edgeAnnotator;
+    private final VertexAnnotator vertexAnnotator;
+
+    /**
+     * Constructs a new network generator for edges with the given label and annotator.
+     *
+     * @param label Label for the generated edges
+     * @param edgeAnnotator EdgeAnnotator to use for annotating newly generated edges.
+     * @param vertexAnnotator VertexAnnotator to use for annotating process vertices.
+     */
+    public AbstractGenerator(String label, EdgeAnnotator edgeAnnotator, VertexAnnotator vertexAnnotator) {
+        if (label==null || label.isEmpty()) throw new IllegalArgumentException("Label cannot be empty");
+        if (edgeAnnotator==null) throw new NullPointerException();
+        if (vertexAnnotator==null) throw new NullPointerException();
+        this.label = label;
+        this.edgeAnnotator = edgeAnnotator;
+        this.vertexAnnotator = vertexAnnotator;
+    }
 
     /**
      * Constructs a new network generator for edges with the given label and annotator.
@@ -22,10 +41,7 @@ public abstract class AbstractGenerator {
      * @param annotator EdgeAnnotator to use for annotating newly generated edges.
      */
     public AbstractGenerator(String label, EdgeAnnotator annotator) {
-        if (label==null || label.isEmpty()) throw new IllegalArgumentException("Label cannot be empty");
-        if (annotator==null) throw new NullPointerException();
-        this.label=label;
-        this.annotator=annotator;
+        this(label, annotator, VertexAnnotator.NONE);
     }
 
     /**
@@ -51,13 +67,26 @@ public abstract class AbstractGenerator {
      * @return
      */
     public final EdgeAnnotator getEdgeAnnotator() {
-        return annotator;
+        return edgeAnnotator;
+    }
+
+    /**
+     * Returns the {@link VertexAnnotator} for this generator
+     * @return
+     */
+    public final VertexAnnotator getVertexAnnotator() {
+        return vertexAnnotator;
     }
     
     protected final Edge addEdge(Graph graph, Vertex out, Vertex in) {
         Edge e = graph.addEdge(null,out,in,label);
-        annotator.annotate(e);
+        edgeAnnotator.annotate(e);
         return e;
+    }
+
+    protected final Vertex processVertex(Vertex vertex, Map<String, Object> context) {
+        vertexAnnotator.annotate(vertex, context);
+        return vertex;
     }
 
 }

--- a/src/main/java/com/tinkerpop/furnace/generators/CommunityGenerator.java
+++ b/src/main/java/com/tinkerpop/furnace/generators/CommunityGenerator.java
@@ -38,6 +38,17 @@ public class CommunityGenerator extends AbstractGenerator {
     /**
      *
      * @param label
+     * @param edgeAnnotator
+     * @param vertexAnnotator
+     * @see AbstractGenerator#AbstractGenerator(String, EdgeAnnotator, VertexAnnotator)
+     */
+    public CommunityGenerator(String label, EdgeAnnotator edgeAnnotator, VertexAnnotator vertexAnnotator) {
+        super(label, edgeAnnotator, vertexAnnotator);
+    }
+
+    /**
+     *
+     * @param label
      * @see AbstractGenerator#AbstractGenerator(String)
      */
     public CommunityGenerator(String label) {
@@ -113,11 +124,13 @@ public class CommunityGenerator extends AbstractGenerator {
         Iterator<Vertex> iter = vertices.iterator();
         ArrayList<ArrayList<Vertex>> communities = new ArrayList<ArrayList<Vertex>>(expectedNumCommunities);
         Distribution communityDist = communitySize.initialize(expectedNumCommunities,numVertices);
+        Map<String, Object> context = new HashMap<String, Object>();
         while (iter.hasNext()) {
             int nextSize = communityDist.nextValue(random);
+            context.put("communityIndex", communities.size());
             ArrayList<Vertex> community = new ArrayList<Vertex>(nextSize);
             for (int i=0;i<nextSize && iter.hasNext();i++) {
-                community.add(iter.next());
+                community.add(processVertex(iter.next(), context));
             }
             if (!community.isEmpty()) communities.add(community);
         }

--- a/src/main/java/com/tinkerpop/furnace/generators/VertexAnnotator.java
+++ b/src/main/java/com/tinkerpop/furnace/generators/VertexAnnotator.java
@@ -1,0 +1,51 @@
+package com.tinkerpop.furnace.generators;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.tinkerpop.blueprints.Vertex;
+
+/**
+ * VertexAnnotator is used to assign properties to generated edges.
+ * 
+ * During synthetic network generation,
+ * {@link #annotate(com.tinkerpop.blueprints.Vertex)} is called on each
+ * processed vertex exactly once. Hence, an implementation of this interface can
+ * assign arbitrary properties to this vertex.
+ * 
+ * (c) Uwe L. Korn (uwelk@xhochy.com)
+ */
+
+public interface VertexAnnotator {
+
+	/**
+	 * Empty {@link VertexAnnotator}. Does not assign any properties
+	 */
+	public final VertexAnnotator NONE = new VertexAnnotator() {
+		@Override
+		public void annotate(Vertex vertex, Map<String, Object> context) {
+			// Do nothing
+		}
+	};
+
+	/**
+	 * Assign every context entry to a property with the same name.
+	 */
+	public final VertexAnnotator COPY_CONTEXT = new VertexAnnotator() {
+		@Override
+		public void annotate(Vertex vertex, Map<String, Object> context) {
+			for(Entry<String, Object> entry: context.entrySet()) {
+				vertex.setProperty(entry.getKey(), entry.getValue());
+			}
+		}
+	};
+
+	/**
+	 * An implementation of this method can assign properties to the vertex.
+	 * This method is called once for each processed vertex.
+	 * 
+	 * @param vertex Processed vertex.
+	 */
+	public void annotate(Vertex vertex, Map<String, Object> context);
+
+}


### PR DESCRIPTION
Currently after Graph generation the information about community membership of vertices is lost. This pull request shall enable the storage about this information. Furthermore I made a more generic interface (influenced by EdgeAnnotator) so that this could be used for other use cases in future.

(It is useful for me as I would like to add various properties afterwards to all vertices depending on their community.)
### Example usage (in scala)

``` scala
import com.tinkerpop.blueprints.impls.tg.TinkerGraph
import com.tinkerpop.furnace.generators.{ CommunityGenerator, EdgeAnnotator, NormalDistribution, PowerLawDistribution, VertexAnnotator }

object Generator {
  def main(args: Array[String]) = {
    val graph = new TinkerGraph
    Range(0, 100).foreach(graph.addVertex(_))
    val generator = new CommunityGenerator("edge", EdgeAnnotator.NONE, VertexAnnotator.COPY_CONTEXT)
    generator.setCommunityDistribution(new NormalDistribution(3));
    generator.setDegreeDistribution(new PowerLawDistribution(2.3));
    generator.setCrossCommunityPercentage(0.1);
    val numEdges = generator.generate(graph, 10, 1000);
  }
}
```
